### PR TITLE
Lf implementations

### DIFF
--- a/src/main/java/com/labforward/api/core/deletion/EntityDeletedResponse.java
+++ b/src/main/java/com/labforward/api/core/deletion/EntityDeletedResponse.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseEntity;
  * Marker class to return on successful
  * entity deleting
  */
-public class EntityDeletedResponse extends ResponseEntity {
+public class EntityDeletedResponse extends ResponseEntity<Object> {
 	
 	public EntityDeletedResponse() {
 		super(HttpStatus.OK);

--- a/src/main/java/com/labforward/api/core/deletion/EntityDeletedResponse.java
+++ b/src/main/java/com/labforward/api/core/deletion/EntityDeletedResponse.java
@@ -1,9 +1,15 @@
 package com.labforward.api.core.deletion;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
 /**
  * Marker class to return on successful
  * entity deleting
  */
-public class EntityDeletedResponse extends NoContentResponse {
-
+public class EntityDeletedResponse extends ResponseEntity {
+	
+	public EntityDeletedResponse() {
+		super(HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/labforward/api/core/deletion/NoContentResponse.java
+++ b/src/main/java/com/labforward/api/core/deletion/NoContentResponse.java
@@ -3,7 +3,7 @@ package com.labforward.api.core.deletion;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-public class NoContentResponse extends ResponseEntity {
+public class NoContentResponse extends ResponseEntity<Object> {
 
 	public NoContentResponse() {
 		super(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/labforward/api/core/exception/BadRequestException.java
+++ b/src/main/java/com/labforward/api/core/exception/BadRequestException.java
@@ -2,6 +2,10 @@ package com.labforward.api.core.exception;
 
 public class BadRequestException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 8729412113874318063L;
 	public static String MESSAGE = "A required parameter is missing";
 
 	public BadRequestException() {

--- a/src/main/java/com/labforward/api/core/exception/EntityValidationException.java
+++ b/src/main/java/com/labforward/api/core/exception/EntityValidationException.java
@@ -4,6 +4,11 @@ import org.springframework.validation.BindingResult;
 
 public class EntityValidationException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -7724416530227795532L;
+
 	public static String MESSAGE = "Bad Request";
 
 	private BindingResult bindingResult;

--- a/src/main/java/com/labforward/api/core/exception/ResourceNotAccessibleException.java
+++ b/src/main/java/com/labforward/api/core/exception/ResourceNotAccessibleException.java
@@ -2,6 +2,11 @@ package com.labforward.api.core.exception;
 
 public class ResourceNotAccessibleException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -6762276711163336080L;
+
 	public ResourceNotAccessibleException(String message) {
 		super(message);
 	}

--- a/src/main/java/com/labforward/api/core/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/labforward/api/core/exception/ResourceNotFoundException.java
@@ -2,6 +2,11 @@ package com.labforward.api.core.exception;
 
 public class ResourceNotFoundException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -102287065344553617L;
+
 	public ResourceNotFoundException() {
 		super();
 	}

--- a/src/main/java/com/labforward/api/core/exception/ServiceUnavailableException.java
+++ b/src/main/java/com/labforward/api/core/exception/ServiceUnavailableException.java
@@ -2,6 +2,11 @@ package com.labforward.api.core.exception;
 
 public class ServiceUnavailableException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -9148311263535548068L;
+
 	public ServiceUnavailableException(String msg) {
 		super(msg);
 	}

--- a/src/main/java/com/labforward/api/core/exception/UnsupportedMediaTypeException.java
+++ b/src/main/java/com/labforward/api/core/exception/UnsupportedMediaTypeException.java
@@ -8,6 +8,11 @@ package com.labforward.api.core.exception;
  */
 public class UnsupportedMediaTypeException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -4694599873449671407L;
+
 	public UnsupportedMediaTypeException() {
 		super("");
 	}

--- a/src/main/java/com/labforward/api/core/exception/UserAgentRequiredException.java
+++ b/src/main/java/com/labforward/api/core/exception/UserAgentRequiredException.java
@@ -2,6 +2,10 @@ package com.labforward.api.core.exception;
 
 public class UserAgentRequiredException extends RuntimeException {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -3168439970739605139L;
 	public static String MESSAGE = "User-Agent header is required";
 
 	public UserAgentRequiredException() {

--- a/src/main/java/com/labforward/api/core/interceptors/RequestAcceptContentTypeInterceptor.java
+++ b/src/main/java/com/labforward/api/core/interceptors/RequestAcceptContentTypeInterceptor.java
@@ -1,14 +1,16 @@
 package com.labforward.api.core.interceptors;
 
-import com.labforward.api.core.exception.UnsupportedMediaTypeException;
-import org.springframework.util.StringUtils;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import com.labforward.api.core.exception.UnsupportedMediaTypeException;
 
 /**
  * Interceptor to validate that client's incoming requests meet guidelines for

--- a/src/main/java/com/labforward/api/core/validation/BeanValidationUtils.java
+++ b/src/main/java/com/labforward/api/core/validation/BeanValidationUtils.java
@@ -1,14 +1,15 @@
 package com.labforward.api.core.validation;
 
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Valid;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class BeanValidationUtils {
 

--- a/src/main/java/com/labforward/api/core/validation/BeanValidationUtils.java
+++ b/src/main/java/com/labforward/api/core/validation/BeanValidationUtils.java
@@ -9,7 +9,7 @@ import java.util.ListIterator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.Valid;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.RegExUtils;
 
 public class BeanValidationUtils {
 
@@ -17,7 +17,7 @@ public class BeanValidationUtils {
 
 	public static boolean setErrorMessageAndReturnFalse(ConstraintValidatorContext constraintValidatorContext,
 	                                                    String field, String message) {
-		String sanitizedMessage = StringUtils.removePattern(message, "(\\{|\\}|\\[|\\])");
+		String sanitizedMessage = RegExUtils.removePattern(message, "(\\{|\\}|\\[|\\])");
 		StringBuilder errorMessage = new StringBuilder().append(field)
 		                                                .append(OBJECT_ERROR_DELIMITER)
 		                                                .append(sanitizedMessage);
@@ -31,7 +31,7 @@ public class BeanValidationUtils {
 	                                      String field, String message) {
 		constraintValidatorContext.disableDefaultConstraintViolation();
 		constraintValidatorContext.buildConstraintViolationWithTemplate(message)
-		                          .addNode(field)
+		                          .addPropertyNode(field)
 		                          .addConstraintViolation();
 	}
 

--- a/src/main/java/com/labforward/api/core/validation/ValidationConfig.java
+++ b/src/main/java/com/labforward/api/core/validation/ValidationConfig.java
@@ -1,13 +1,13 @@
 package com.labforward.api.core.validation;
 
+import javax.validation.Validator;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
-
-import javax.validation.Validator;
 
 /*
  * Used for manually validating method parameter beans (JSR-303) in service layer

--- a/src/main/java/com/labforward/api/hello/controller/HelloController.java
+++ b/src/main/java/com/labforward/api/hello/controller/HelloController.java
@@ -1,11 +1,5 @@
 package com.labforward.api.hello.controller;
 
-import com.labforward.api.core.creation.EntityCreatedResponse;
-import com.labforward.api.core.deletion.EntityDeletedResponse;
-import com.labforward.api.core.exception.ResourceNotFoundException;
-import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
-
 import java.net.URI;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,6 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.labforward.api.core.creation.EntityCreatedResponse;
+import com.labforward.api.core.deletion.EntityDeletedResponse;
+import com.labforward.api.core.exception.ResourceNotFoundException;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
 
 @RestController
 public class HelloController {

--- a/src/main/java/com/labforward/api/hello/controller/HelloController.java
+++ b/src/main/java/com/labforward/api/hello/controller/HelloController.java
@@ -1,6 +1,7 @@
 package com.labforward.api.hello.controller;
 
 import java.net.URI;
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -30,13 +31,13 @@ public class HelloController {
 
 	@RequestMapping(value = "/hello", method = RequestMethod.GET)
 	@ResponseBody
-	public Greeting helloWorld() {
-		return getHello(HelloWorldService.DEFAULT_ID);
+	public List<Greeting> getGreetings() {
+		return helloWorldService.getGreetings();
 	}
 
 	@RequestMapping(value = "/hello/{id}", method = RequestMethod.GET)
 	@ResponseBody
-	public Greeting getHello(@PathVariable String id) {
+	public Greeting getGreeting(@PathVariable String id) {
 		return helloWorldService.getGreeting(id)
 		                        .orElseThrow(() -> new ResourceNotFoundException(GREETING_NOT_FOUND));
 	}

--- a/src/main/java/com/labforward/api/hello/controller/HelloController.java
+++ b/src/main/java/com/labforward/api/hello/controller/HelloController.java
@@ -43,4 +43,9 @@ public class HelloController {
 	public Greeting updateGreeting(@PathVariable String id, @RequestBody Greeting request) {
 		return helloWorldService.updateGreeting(id, request);
 	}
+	
+	@RequestMapping(value = "/hello/{id}", method = RequestMethod.DELETE)
+	public void deleteGreeting(@PathVariable String id) {
+		helloWorldService.deleteGreeting(id);
+	}
 }

--- a/src/main/java/com/labforward/api/hello/controller/HelloController.java
+++ b/src/main/java/com/labforward/api/hello/controller/HelloController.java
@@ -1,8 +1,15 @@
 package com.labforward.api.hello.controller;
 
+import com.labforward.api.core.creation.EntityCreatedResponse;
+import com.labforward.api.core.deletion.EntityDeletedResponse;
 import com.labforward.api.core.exception.ResourceNotFoundException;
 import com.labforward.api.hello.domain.Greeting;
 import com.labforward.api.hello.service.HelloWorldService;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,8 +42,12 @@ public class HelloController {
 	}
 
 	@RequestMapping(value = "/hello", method = RequestMethod.POST)
-	public Greeting createGreeting(@RequestBody Greeting request) {
-		return helloWorldService.createGreeting(request);
+	public EntityCreatedResponse<Greeting> createGreeting(@RequestBody Greeting request,
+			HttpServletRequest httpRequest) {
+		Greeting created = helloWorldService.createGreeting(request);
+		String requestUrl = httpRequest.getRequestURL().toString();		
+		URI createdUri = URI.create(requestUrl + "/" + created.getId());
+		return new EntityCreatedResponse<Greeting>(created, createdUri);
 	}
 	
 	@RequestMapping(value = "/hello/{id}", method = RequestMethod.PUT)
@@ -45,7 +56,8 @@ public class HelloController {
 	}
 	
 	@RequestMapping(value = "/hello/{id}", method = RequestMethod.DELETE)
-	public void deleteGreeting(@PathVariable String id) {
+	public EntityDeletedResponse deleteGreeting(@PathVariable String id) {
 		helloWorldService.deleteGreeting(id);
+		return new EntityDeletedResponse();
 	}
 }

--- a/src/main/java/com/labforward/api/hello/controller/HelloController.java
+++ b/src/main/java/com/labforward/api/hello/controller/HelloController.java
@@ -38,4 +38,9 @@ public class HelloController {
 	public Greeting createGreeting(@RequestBody Greeting request) {
 		return helloWorldService.createGreeting(request);
 	}
+	
+	@RequestMapping(value = "/hello/{id}", method = RequestMethod.PUT)
+	public Greeting updateGreeting(@PathVariable String id, @RequestBody Greeting request) {
+		return helloWorldService.updateGreeting(id, request);
+	}
 }

--- a/src/main/java/com/labforward/api/hello/domain/Greeting.java
+++ b/src/main/java/com/labforward/api/hello/domain/Greeting.java
@@ -1,9 +1,9 @@
 package com.labforward.api.hello.domain;
 
+import javax.validation.constraints.NotEmpty;
+
 import com.labforward.api.core.validation.Entity;
 import com.labforward.api.core.validation.EntityUpdateValidatorGroup;
-
-import javax.validation.constraints.NotEmpty;
 
 /**
  * Simple greeting message for dev purposes
@@ -27,7 +27,6 @@ public class Greeting implements Entity {
 
 	public Greeting(String message) {
 		this.message = message;
-		this.id = id;
 	}
 
 	public String getId() {

--- a/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
+++ b/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
@@ -32,6 +32,11 @@ public class HelloWorldService {
 	private static Greeting getDefault() {
 		return new Greeting(DEFAULT_ID, DEFAULT_MESSAGE);
 	}
+	
+	public Greeting updateGreeting(String id, Greeting request) {
+		entityValidator.validateUpdate(id, request);
+		return save(request);
+	}
 
 	public Greeting createGreeting(Greeting request) {
 		entityValidator.validateCreate(request);

--- a/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
+++ b/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
@@ -58,7 +58,7 @@ public class HelloWorldService {
 	}
 	
 	public List<Greeting> getGreetings() {
-		Collection<Greeting> greetings = new ArrayList<Greeting>(this.greetings.values());
+		Collection<Greeting> greetings = this.greetings.values();
 		return new ArrayList<Greeting>(greetings);
 	}
 

--- a/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
+++ b/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
@@ -1,5 +1,6 @@
 package com.labforward.api.hello.service;
 
+import com.labforward.api.core.exception.ResourceNotFoundException;
 import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,14 @@ public class HelloWorldService {
 
 	private static Greeting getDefault() {
 		return new Greeting(DEFAULT_ID, DEFAULT_MESSAGE);
+	}
+	
+	public void deleteGreeting(String id) {
+		entityValidator.validateDelete(id);
+		if (!this.greetings.containsKey(id)) {
+			throw new ResourceNotFoundException();
+		}
+		this.greetings.remove(id);
 	}
 	
 	public Greeting updateGreeting(String id, Greeting request) {

--- a/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
+++ b/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
@@ -38,7 +38,7 @@ public class HelloWorldService {
 	}
 	
 	public void deleteGreeting(String id) {
-		entityValidator.validateDelete(id);
+		//entityValidator.validateDelete(id);
 		if (!this.greetings.containsKey(id)) {
 			throw new ResourceNotFoundException();
 		}

--- a/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
+++ b/src/main/java/com/labforward/api/hello/service/HelloWorldService.java
@@ -5,7 +5,10 @@ import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -52,6 +55,11 @@ public class HelloWorldService {
 
 		request.setId(UUID.randomUUID().toString());
 		return save(request);
+	}
+	
+	public List<Greeting> getGreetings() {
+		Collection<Greeting> greetings = new ArrayList<Greeting>(this.greetings.values());
+		return new ArrayList<Greeting>(greetings);
 	}
 
 	public Optional<Greeting> getGreeting(String id) {

--- a/src/test/java/com/labforward/api/hello/HelloControllerTest.java
+++ b/src/test/java/com/labforward/api/hello/HelloControllerTest.java
@@ -80,13 +80,13 @@ public class HelloControllerTest extends MVCIntegrationTest {
 	}
 
 	@Test
-	public void postHelloIsOKWhenRequiredGreetingProvided() throws Exception {
+	public void postHelloIsCreatedWhenRequiredGreetingProvided() throws Exception {
 		Greeting hello = new Greeting(HELLO_LUKE);
 		final String body = getGreetingBody(hello);
 
 		mockMvc.perform(post("/hello").contentType(MediaType.APPLICATION_JSON)
 		                              .content(body))
-		       .andExpect(status().isOk())
+		       .andExpect(status().isCreated())
 		       .andExpect(jsonPath("$.message", is(hello.getMessage())));
 	}
 	

--- a/src/test/java/com/labforward/api/hello/HelloControllerTest.java
+++ b/src/test/java/com/labforward/api/hello/HelloControllerTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -131,7 +132,7 @@ public class HelloControllerTest extends MVCIntegrationTest {
 	}
 	
 	@Test
-	public void putHelloReturnsUnprocessableEntityWhenIdIsNotProvidedAsQueryParameter() throws Exception {
+	public void putHelloReturnsMethodNotAllowedWhenIdIsNotProvidedAsQueryParameter() throws Exception {
 		Greeting hello = new Greeting(DUMMY_ID, HELLO_LUKE);
 		final String body = getGreetingBody(hello);
 		mockMvc.perform(put("/hello").content(body).contentType(MediaType.APPLICATION_JSON))
@@ -165,7 +166,31 @@ public class HelloControllerTest extends MVCIntegrationTest {
 		                              .content(body))
 		       .andExpect(status().isOk())
 		       .andExpect(jsonPath("$.message", is(hello.getMessage())));
+	}
+	
+	@Test
+	public void deleteHelloReturnsMethodNotAllowedWhenIdIsNotProvidedAsQueryParameter() throws Exception {
+		mockMvc.perform(delete("/hello").contentType(MediaType.APPLICATION_JSON))
+		       .andExpect(status().isMethodNotAllowed());
+	}
+
+	@Test
+	public void deleteHelloIsOKWhenRequiredGreetingProvided() throws Exception {
+		Greeting hello = new Greeting(HELLO_LUKE);
+		final String body = getGreetingBody(hello);
+		mockMvc.perform(post("/hello").contentType(MediaType.APPLICATION_JSON)
+		                              .content(body));
+
+		mockMvc.perform(delete("/hello/" + DUMMY_ID).contentType(MediaType.APPLICATION_JSON)
+													.content(body))
+			.andExpect(status().isOk());
 	}	
+	
+	@Test
+	public void deleteHelloIsNotFoundWhenGreetingDoesNotExist() throws Exception {
+		mockMvc.perform(delete("/hello/" + DUMMY_ID).contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound());
+	}		
 
 	private String getGreetingBody(Greeting greeting) throws JSONException {
 		JSONObject json = new JSONObject().put("message", greeting.getMessage());

--- a/src/test/java/com/labforward/api/hello/HelloControllerTest.java
+++ b/src/test/java/com/labforward/api/hello/HelloControllerTest.java
@@ -1,9 +1,15 @@
 package com.labforward.api.hello;
 
-import com.labforward.api.common.MVCIntegrationTest;
-import com.labforward.api.core.validation.EntityValidator;
-import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -13,15 +19,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.labforward.api.common.MVCIntegrationTest;
+import com.labforward.api.core.validation.EntityValidator;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
 
 @AutoConfigureMockMvc
 @RunWith(SpringRunner.class)

--- a/src/test/java/com/labforward/api/hello/HelloWorldServiceTest.java
+++ b/src/test/java/com/labforward/api/hello/HelloWorldServiceTest.java
@@ -1,6 +1,7 @@
 package com.labforward.api.hello;
 
 import com.labforward.api.core.exception.EntityValidationException;
+import com.labforward.api.core.exception.ResourceNotFoundException;
 import com.labforward.api.hello.domain.Greeting;
 import com.labforward.api.hello.service.HelloWorldService;
 import org.junit.Assert;
@@ -82,5 +83,25 @@ public class HelloWorldServiceTest {
 		Greeting updated = helloService.updateGreeting(created.getId(), created);
 		
 		Assert.assertEquals(HELLO_JANE, updated.getMessage());
+	}
+	
+	@Test(expected = ResourceNotFoundException.class)
+	public void deleteGreetingWithEmptyIdThrowsException() {
+		helloService.deleteGreeting(EMPTY_ID);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void deleteGreetingWithNullIdThrowsException() {
+		helloService.deleteGreeting(null);
+	}
+	
+	@Test
+	public void deleteGreetingOKWhenValidRequest() {
+		Greeting request = new Greeting(HELLO_LUKE);
+		Greeting created = helloService.createGreeting(request);
+		helloService.deleteGreeting(created.getId());
+		Optional<Greeting> deleted = helloService.getGreeting(created.getId());
+		
+		Assert.assertTrue(deleted.isEmpty());
 	}
 }

--- a/src/test/java/com/labforward/api/hello/HelloWorldServiceTest.java
+++ b/src/test/java/com/labforward/api/hello/HelloWorldServiceTest.java
@@ -1,9 +1,7 @@
 package com.labforward.api.hello;
 
-import com.labforward.api.core.exception.EntityValidationException;
-import com.labforward.api.core.exception.ResourceNotFoundException;
-import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,7 +9,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Optional;
+import com.labforward.api.core.exception.EntityValidationException;
+import com.labforward.api.core.exception.ResourceNotFoundException;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest

--- a/src/test/java/com/labforward/api/hello/HelloWorldServiceTest.java
+++ b/src/test/java/com/labforward/api/hello/HelloWorldServiceTest.java
@@ -16,6 +16,12 @@ import java.util.Optional;
 @SpringBootTest
 public class HelloWorldServiceTest {
 
+	private static final String EMPTY_MESSAGE = "";
+	private static final String EMPTY_ID = "";
+	private static final String DUMMY_ID = "123";
+	private static final String HELLO_LUKE = "Hello Luke";
+	private static final String HELLO_JANE = "Hello Jane";
+
 	@Autowired
 	private HelloWorldService helloService;
 
@@ -32,7 +38,6 @@ public class HelloWorldServiceTest {
 
 	@Test(expected = EntityValidationException.class)
 	public void createGreetingWithEmptyMessageThrowsException() {
-		final String EMPTY_MESSAGE = "";
 		helloService.createGreeting(new Greeting(EMPTY_MESSAGE));
 	}
 
@@ -43,10 +48,39 @@ public class HelloWorldServiceTest {
 
 	@Test
 	public void createGreetingOKWhenValidRequest() {
-		final String HELLO_LUKE = "Hello Luke";
 		Greeting request = new Greeting(HELLO_LUKE);
 
 		Greeting created = helloService.createGreeting(request);
 		Assert.assertEquals(HELLO_LUKE, created.getMessage());
+	}
+	
+	@Test(expected = EntityValidationException.class)
+	public void updateGreetingWithEmptyMessageThrowsException() {
+		helloService.updateGreeting(DUMMY_ID, new Greeting(EMPTY_MESSAGE));
+	}
+
+	@Test(expected = EntityValidationException.class)
+	public void updateGreetingWithNullMessageThrowsException() {
+		helloService.updateGreeting(DUMMY_ID, new Greeting(null));
+	}
+	
+	@Test(expected = EntityValidationException.class)
+	public void updateGreetingWithEmptyIdThrowsException() {
+		helloService.updateGreeting(EMPTY_ID, new Greeting(EMPTY_ID, HELLO_LUKE));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void updateGreetingWithNullIdThrowsException() {
+		helloService.updateGreeting(null, new Greeting(null, HELLO_LUKE));
+	}
+
+	@Test
+	public void updateGreetingOKWhenValidRequest() {
+		Greeting request = new Greeting(HELLO_LUKE);
+		Greeting created = helloService.createGreeting(request);
+		created.setMessage(HELLO_JANE);
+		Greeting updated = helloService.updateGreeting(created.getId(), created);
+		
+		Assert.assertEquals(HELLO_JANE, updated.getMessage());
 	}
 }

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerDeleteTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerDeleteTest.java
@@ -1,33 +1,17 @@
 package com.labforward.api.hello.controller;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.labforward.api.common.MVCIntegrationTest;
-import com.labforward.api.core.creation.EntityCreatedResponse;
-import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
 
 public class HelloControllerDeleteTest extends HelloControllerTest {
 	

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerDeleteTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerDeleteTest.java
@@ -1,0 +1,65 @@
+package com.labforward.api.hello.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.labforward.api.common.MVCIntegrationTest;
+import com.labforward.api.core.creation.EntityCreatedResponse;
+import com.labforward.api.core.validation.EntityValidator;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
+
+public class HelloControllerDeleteTest extends HelloControllerTest {
+	
+	@Autowired
+	private ObjectMapper objectMapper;
+	
+	@Test
+	public void deleteHelloReturnsMethodNotAllowedWhenIdIsNotProvidedAsQueryParameter() throws Exception {
+		mockMvc.perform(delete("/hello").contentType(MediaType.APPLICATION_JSON))
+		       .andExpect(status().isMethodNotAllowed());
+	}
+
+	@Test
+	public void deleteHelloIsOKWhenRequiredGreetingProvided() throws Exception {
+		Greeting hello = new Greeting(HELLO_LUKE);
+		final String body = getGreetingBody(hello);
+		
+		ResultActions resultActions = mockMvc.perform(post("/hello").contentType(MediaType.APPLICATION_JSON)
+																	.content(body));
+		MvcResult result = resultActions.andReturn();
+		String contentAsString = result.getResponse().getContentAsString();
+		Greeting response = objectMapper.readValue(contentAsString, Greeting.class);	
+		
+		mockMvc.perform(delete("/hello/" + response.getId()).contentType(MediaType.APPLICATION_JSON)
+															.content(body))
+		.andExpect(status().isOk());
+	}	
+	
+	@Test
+	public void deleteHelloIsNotFoundWhenGreetingDoesNotExist() throws Exception {
+		mockMvc.perform(delete("/hello/" + DUMMY_ID).contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound());
+	}
+	
+}

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerGetTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerGetTest.java
@@ -1,27 +1,12 @@
 package com.labforward.api.hello.controller;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import com.labforward.api.common.MVCIntegrationTest;
-import com.labforward.api.core.validation.EntityValidator;
-import com.labforward.api.hello.domain.Greeting;
 import com.labforward.api.hello.service.HelloWorldService;
 
 public class HelloControllerGetTest extends HelloControllerTest {

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerGetTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerGetTest.java
@@ -1,0 +1,36 @@
+package com.labforward.api.hello.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.labforward.api.common.MVCIntegrationTest;
+import com.labforward.api.core.validation.EntityValidator;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
+
+public class HelloControllerGetTest extends HelloControllerTest {
+
+	@Test
+	public void getHelloIsOKAndReturnsValidJSON() throws Exception {
+		mockMvc.perform(get("/hello"))
+		       .andExpect(status().isOk())
+		       .andExpect(jsonPath("$.id", is(HelloWorldService.DEFAULT_ID)))
+		       .andExpect(jsonPath("$.message", is(HelloWorldService.DEFAULT_MESSAGE)));
+	}
+}

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerGetTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerGetTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.contains;
 
 import org.junit.Test;
 
@@ -14,6 +15,14 @@ public class HelloControllerGetTest extends HelloControllerTest {
 	@Test
 	public void getHelloIsOKAndReturnsValidJSON() throws Exception {
 		mockMvc.perform(get("/hello"))
+		       .andExpect(status().isOk())
+		       .andExpect(jsonPath("$[*].id", contains(HelloWorldService.DEFAULT_ID)))
+		       .andExpect(jsonPath("$[*].message", contains(HelloWorldService.DEFAULT_MESSAGE)));
+	}
+	
+	@Test
+	public void getHelloIsOKWhenCalledWithDefaultIdReturnsValidJSON() throws Exception {
+		mockMvc.perform(get("/hello/" + HelloWorldService.DEFAULT_ID))
 		       .andExpect(status().isOk())
 		       .andExpect(jsonPath("$.id", is(HelloWorldService.DEFAULT_ID)))
 		       .andExpect(jsonPath("$.message", is(HelloWorldService.DEFAULT_MESSAGE)));

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerPostTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerPostTest.java
@@ -3,26 +3,14 @@ package com.labforward.api.hello.controller;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import com.labforward.api.common.MVCIntegrationTest;
-import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
 
 public class HelloControllerPostTest extends HelloControllerTest {
 

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerPostTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerPostTest.java
@@ -1,0 +1,79 @@
+package com.labforward.api.hello.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.labforward.api.common.MVCIntegrationTest;
+import com.labforward.api.core.validation.EntityValidator;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
+
+public class HelloControllerPostTest extends HelloControllerTest {
+
+	@Test
+	public void postHelloReturnsUnprocessableEntityWhenMessageMissing() throws Exception {
+		String body = "{}";
+		mockMvc.perform(post("/hello").content(body)
+		                              .contentType(MediaType.APPLICATION_JSON))
+		       .andExpect(status().isUnprocessableEntity())
+		       .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+		       .andExpect(jsonPath("$.validationErrors[*].field", contains("message")));
+	}
+
+	@Test
+	public void postHelloReturnsUnprocessableEntityWhenUnexpectedAttributeProvided() throws Exception {
+		String body = "{ \"tacos\":\"value\" }";
+		mockMvc.perform(post("/hello").content(body).contentType(MediaType.APPLICATION_JSON))
+		       .andExpect(status().isUnprocessableEntity());
+		// TODO(yigitalp): Does not append the MESSAGE_UNRECOGNIZED_PROPERTY. To be fixed.
+		//.andExpect(jsonPath("$.message", containsString(GlobalControllerAdvice.MESSAGE_UNRECOGNIZED_PROPERTY)));
+			
+	}
+
+	@Test
+	public void postHelloReturnsUnprocessableEntityWhenMessageEmptyString() throws Exception {
+		Greeting emptyMessage = new Greeting(EMPTY_MESSAGE);
+		final String body = getGreetingBody(emptyMessage);
+
+		mockMvc.perform(post("/hello").content(body)
+		                              .contentType(MediaType.APPLICATION_JSON))
+		       .andExpect(status().isUnprocessableEntity())
+		       .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+		       .andExpect(jsonPath("$.validationErrors[*].field", contains("message")));
+	}
+	
+	@Test
+	public void postHelloReturnsBadRequestWhenBrokenJsonInputProvided() throws Exception {
+		String body = "{ \"tacos\":\"value\" ";
+		mockMvc.perform(post("/hello").content(body).contentType(MediaType.APPLICATION_JSON))
+		       .andExpect(status().isBadRequest());
+	}
+
+	@Test
+	public void postHelloIsCreatedWhenRequiredGreetingProvided() throws Exception {
+		Greeting hello = new Greeting(HELLO_LUKE);
+		final String body = getGreetingBody(hello);
+
+		mockMvc.perform(post("/hello").contentType(MediaType.APPLICATION_JSON)
+		                              .content(body))
+		       .andExpect(status().isCreated())
+		       .andExpect(jsonPath("$.message", is(hello.getMessage())));
+	}
+
+}

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerPutTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerPutTest.java
@@ -3,26 +3,15 @@ package com.labforward.api.hello.controller;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import com.labforward.api.common.MVCIntegrationTest;
 import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
 
 public class HelloControllerPutTest extends HelloControllerTest {
 	

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerPutTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerPutTest.java
@@ -1,4 +1,4 @@
-package com.labforward.api.hello;
+package com.labforward.api.hello.controller;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
@@ -24,72 +24,7 @@ import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
 import com.labforward.api.hello.service.HelloWorldService;
 
-@AutoConfigureMockMvc
-@RunWith(SpringRunner.class)
-@SpringBootTest
-public class HelloControllerTest extends MVCIntegrationTest {
-	
-	private static final String EMPTY_MESSAGE = "";
-	private static final String HELLO_LUKE = "Hello Luke";
-	private static final String DUMMY_ID = "123";
-
-	@Test
-	public void getHelloIsOKAndReturnsValidJSON() throws Exception {
-		mockMvc.perform(get("/hello"))
-		       .andExpect(status().isOk())
-		       .andExpect(jsonPath("$.id", is(HelloWorldService.DEFAULT_ID)))
-		       .andExpect(jsonPath("$.message", is(HelloWorldService.DEFAULT_MESSAGE)));
-	}
-
-	@Test
-	public void postHelloReturnsUnprocessableEntityWhenMessageMissing() throws Exception {
-		String body = "{}";
-		mockMvc.perform(post("/hello").content(body)
-		                              .contentType(MediaType.APPLICATION_JSON))
-		       .andExpect(status().isUnprocessableEntity())
-		       .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-		       .andExpect(jsonPath("$.validationErrors[*].field", contains("message")));
-	}
-
-	@Test
-	public void postHelloReturnsUnprocessableEntityWhenUnexpectedAttributeProvided() throws Exception {
-		String body = "{ \"tacos\":\"value\" }";
-		mockMvc.perform(post("/hello").content(body).contentType(MediaType.APPLICATION_JSON))
-		       .andExpect(status().isUnprocessableEntity());
-		// TODO(yigitalp): Does not append the MESSAGE_UNRECOGNIZED_PROPERTY. To be fixed.
-		//.andExpect(jsonPath("$.message", containsString(GlobalControllerAdvice.MESSAGE_UNRECOGNIZED_PROPERTY)));
-			
-	}
-
-	@Test
-	public void postHelloReturnsUnprocessableEntityWhenMessageEmptyString() throws Exception {
-		Greeting emptyMessage = new Greeting(EMPTY_MESSAGE);
-		final String body = getGreetingBody(emptyMessage);
-
-		mockMvc.perform(post("/hello").content(body)
-		                              .contentType(MediaType.APPLICATION_JSON))
-		       .andExpect(status().isUnprocessableEntity())
-		       .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-		       .andExpect(jsonPath("$.validationErrors[*].field", contains("message")));
-	}
-	
-	@Test
-	public void postHelloReturnsBadRequestWhenBrokenJsonInputProvided() throws Exception {
-		String body = "{ \"tacos\":\"value\" ";
-		mockMvc.perform(post("/hello").content(body).contentType(MediaType.APPLICATION_JSON))
-		       .andExpect(status().isBadRequest());
-	}
-
-	@Test
-	public void postHelloIsCreatedWhenRequiredGreetingProvided() throws Exception {
-		Greeting hello = new Greeting(HELLO_LUKE);
-		final String body = getGreetingBody(hello);
-
-		mockMvc.perform(post("/hello").contentType(MediaType.APPLICATION_JSON)
-		                              .content(body))
-		       .andExpect(status().isCreated())
-		       .andExpect(jsonPath("$.message", is(hello.getMessage())));
-	}
+public class HelloControllerPutTest extends HelloControllerTest {
 	
 	@Test
 	public void putHelloReturnsUnprocessableEntityWhenIdMissing() throws Exception {
@@ -167,40 +102,6 @@ public class HelloControllerTest extends MVCIntegrationTest {
 		                              .content(body))
 		       .andExpect(status().isOk())
 		       .andExpect(jsonPath("$.message", is(hello.getMessage())));
-	}
-	
-	@Test
-	public void deleteHelloReturnsMethodNotAllowedWhenIdIsNotProvidedAsQueryParameter() throws Exception {
-		mockMvc.perform(delete("/hello").contentType(MediaType.APPLICATION_JSON))
-		       .andExpect(status().isMethodNotAllowed());
-	}
-
-	@Test
-	public void deleteHelloIsOKWhenRequiredGreetingProvided() throws Exception {
-		Greeting hello = new Greeting(HELLO_LUKE);
-		final String body = getGreetingBody(hello);
-		mockMvc.perform(post("/hello").contentType(MediaType.APPLICATION_JSON)
-		                              .content(body));
-
-		mockMvc.perform(delete("/hello/" + DUMMY_ID).contentType(MediaType.APPLICATION_JSON)
-													.content(body))
-			.andExpect(status().isOk());
-	}	
-	
-	@Test
-	public void deleteHelloIsNotFoundWhenGreetingDoesNotExist() throws Exception {
-		mockMvc.perform(delete("/hello/" + DUMMY_ID).contentType(MediaType.APPLICATION_JSON))
-			.andExpect(status().isNotFound());
-	}		
-
-	private String getGreetingBody(Greeting greeting) throws JSONException {
-		JSONObject json = new JSONObject().put("message", greeting.getMessage());
-
-		if (greeting.getId() != null) {
-			json.put("id", greeting.getId());
-		}
-
-		return json.toString();
 	}
 
 }

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerTest.java
@@ -1,32 +1,14 @@
 package com.labforward.api.hello.controller;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.labforward.api.common.MVCIntegrationTest;
-import com.labforward.api.core.validation.EntityValidator;
 import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
 
 @AutoConfigureMockMvc
 @RunWith(SpringRunner.class)

--- a/src/test/java/com/labforward/api/hello/controller/HelloControllerTest.java
+++ b/src/test/java/com/labforward/api/hello/controller/HelloControllerTest.java
@@ -1,0 +1,49 @@
+package com.labforward.api.hello.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.labforward.api.common.MVCIntegrationTest;
+import com.labforward.api.core.validation.EntityValidator;
+import com.labforward.api.hello.domain.Greeting;
+import com.labforward.api.hello.service.HelloWorldService;
+
+@AutoConfigureMockMvc
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public abstract class HelloControllerTest extends MVCIntegrationTest {
+	
+	protected static final String EMPTY_MESSAGE = "";
+	protected static final String HELLO_LUKE = "Hello Luke";
+	protected static final String DUMMY_ID = "123";
+
+	protected String getGreetingBody(Greeting greeting) throws JSONException {
+		JSONObject json = new JSONObject().put("message", greeting.getMessage());
+
+		if (greeting.getId() != null) {
+			json.put("id", greeting.getId());
+		}
+
+		return json.toString();
+	}
+}

--- a/src/test/java/com/labforward/api/hello/service/HelloWorldServiceTest.java
+++ b/src/test/java/com/labforward/api/hello/service/HelloWorldServiceTest.java
@@ -1,5 +1,6 @@
 package com.labforward.api.hello.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Assert;
@@ -29,6 +30,15 @@ public class HelloWorldServiceTest {
 	public HelloWorldServiceTest() {
 	}
 
+	@Test
+	public void getGreetingsReturnsDefaultAllGreeting() {
+		Optional<Greeting> greeting = helloService.getDefaultGreeting();
+		List<Greeting> greetings = helloService.getGreetings();
+		
+		Assert.assertTrue(greetings.contains(greeting.get()));
+	}
+
+	
 	@Test
 	public void getDefaultGreetingIsOK() {
 		Optional<Greeting> greeting = helloService.getDefaultGreeting();

--- a/src/test/java/com/labforward/api/hello/service/HelloWorldServiceTest.java
+++ b/src/test/java/com/labforward/api/hello/service/HelloWorldServiceTest.java
@@ -1,4 +1,4 @@
-package com.labforward.api.hello;
+package com.labforward.api.hello.service;
 
 import java.util.Optional;
 
@@ -12,7 +12,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.labforward.api.core.exception.EntityValidationException;
 import com.labforward.api.core.exception.ResourceNotFoundException;
 import com.labforward.api.hello.domain.Greeting;
-import com.labforward.api.hello.service.HelloWorldService;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest


### PR DESCRIPTION
# Developments
  - Added new ```PUT``` & ```DELETE``` endpoints.
  - Added List support for parameterless ```GET``` endpoint.
  - Wrote service & controller tests.
  - Fixed a failing test case due to HTTP Response codes (400 vs. 422).
  - Added Location link to the response of  ```POST``` endpoint as an example since it's structure is implemented in an inner class ```EntityCreatedResponse```. (*My approach is brute-force here, I guess best practice is using Spring HATEOAS for link building.*)

# Refactoring
  - Splitted large ```HelloControllerTest``` class into separate classes. I probably had broken the naming conventions though.
  - Cleaned all the warnings (not important, but I like to keep the codebase free of warnings).
  - Changed some namings in Test classes to better express the methods they belong to.

# Notes about the Changes
- Since I haven't used Spring before (*thanks to this challenge, I'm better than yesterday*) and my Java knowledge is a bit rusty I wasn't very sure about the conventions & best practices. That's why I did not want to refactor and change the existing code too much. The classes and methods were pretty clean and intelligible. ```GlobalControllerAdvice``` class is a bit large, maybe it can be splitted into smaller chunks with the help of a logical grouping of its handler methods. Just fixed a few minor typo-like mistakes and method names.
- Async support can be added to API methods, but I did not do it since it would take some time for me learn Async basics in Java & Spring.
- Currently, ```PUT``` method inserts new object if the submitted one does not exist. Ideally, it should return ```204 - No Content```. Similarly, ```POST``` method updates the object if it exists instead of returning ```409 - Conflict``` or [another appropriate error response](https://stackoverflow.com/questions/3825990/http-response-code-for-post-when-resource-already-exists). However, these choices are mostly context/business logic dependent in API's, so I did not change these (*which is the easy way :)*).
- ```com.labforward.api.core.creation``` and ```com.labforward.api.core.deletion``` packages seemed wrongly placed to me. They are used in REST API so their places should be under ```com.labforward.api.hello``` package probably. I have some other confusions and questions about the package hierarchy and names but it would be more efficient to discuss than writing here.

# UI Design

I preferred to submit the UI Design part here, in a textual form. Without any knowledge about the consumer of the API or the platforms in which this API is exposed to, I thought it's better to cover some basics about UI instead of design it out of the blue.
![Asana Task List](https://i.ibb.co/0GjtMyG/greetings.png)

  - Adding an interactive document (for .NET, the best is Swagger, can also be used for Java) for the API would be first step to take. That would be helpful for all developers who will consume the API, it's also a some kind of UI after all.
  - The UI design I would pick can be affected by requirements such as:
    - The roles of users accessing the API i.e. some users may only read while others would edit or delete resources.
    - The platforms that will consume the API such as Web, Mobile, Desktop apps in terms of their own features.
  - If I design a UI for this CRUD API, I would follow some checklists about UI best practices especially for [CRUD based UIs](https://medium.com/flawless-app-stories/designers-guide-to-user-data-and-crud-4e53f7c5150d).
  - If I think of an end user, not a business customer but a regular B2C user, I would come up with these considerations:
    - Since there is only single property ```message```and no other visual or external sources, a simple design like a TODO list approach would suffice. Messages can be presented line by line. Floated to right of the line, a DELETE button can be added. At a relevant position in screen an ADD button may be placed. Or, a text input can be placed under all greetings to provide inline addition (*again, as in TODO apps, the task list of Asana would be a nice example, image above*).
    - If the Greeting objects are sized too much, search, pagination or infinite scroll would be needed. However the current API does not support this.
    - Giving users options like Undo, Redo or DeleteAll where the API does not support organically but can be implemented on the client side.
 - If this design considerations are lacking for you I can build a React based PoC in a few days. Currently, I'm learning React, would practice on this.
